### PR TITLE
Fix missing placeholders rule and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,16 @@ At the moment rebellion is meant to be used as a CLI tool and can't be used as a
 * [pub.dev page](https://pub.dev/packages/rebellion)
 * [Rebel App Studio](https://rebelappstudio.com)
 
+## Installation
+
+```sh
+dart pub global activate rebellion
+```
 
 ## Example
 
 ```
-> rebellion analyze ./l10n/
+> rebellion analyze ./lib/l10n/
 
 l10n/intl_fi.arb: all caps string key "key2"
 l10n/intl_fi.arb: no @@locale key found
@@ -33,18 +38,12 @@ l10n/intl_en.arb: key "key_5" does not match selected naming convention (camel c
 8 issues found
 ```
 
-## Installation
-
-```sh
-dart pub global activate rebellion
-```
-
 ## Analyze ARB files
 
 Find problems in ARB files:
 
 ```sh
-rebellion analyze ./l10n/
+rebellion analyze ./lib/l10n/
 ```
 
 See Configuration section below to customize the set of rules.
@@ -54,7 +53,7 @@ See Configuration section below to customize the set of rules.
 Find missing translations:
 
 ```sh
-> rebellion diff ./l10n/
+> rebellion diff ./lib/l10n/
 
 l10n/intl_fi.arb: 2 missing translations:
  - key4
@@ -70,7 +69,7 @@ By default this command prints missing translations to the console. You can inst
 Sort ARB files alphabetically, in reverse alphabetical order or follow main ARB file's order:
 
 ```sh
-rebellion sort ./l10n/
+rebellion sort ./lib/l10n/
 ```
 
 Use `--sorting` to change sorting: `alphabetical` (default), `alphabetical-reverse` or `follow-main-file`

--- a/lib/rebellion.dart
+++ b/lib/rebellion.dart
@@ -1,1 +1,2 @@
+/// A linter for ARB files
 library rebellion;

--- a/lib/src/analyze/analyze.dart
+++ b/lib/src/analyze/analyze.dart
@@ -23,8 +23,14 @@ class AnalyzeCommand extends Command {
     final parsedFiles = getFilesAndFolders(options, argResults);
     final enabledRules = options.enabledRules();
 
-    final issuesFound =
-        enabledRules.map((rule) => rule.run(parsedFiles, options)).sum;
+    final issuesFound = enabledRules.map((rule) {
+      final issues = rule.run(parsedFiles, options);
+
+      // Print a new line to separate issues from different rules
+      if (issues > 0) logError('');
+
+      return issues;
+    }).sum;
 
     if (issuesFound > 0) {
       logError(

--- a/lib/src/analyze/analyze.dart
+++ b/lib/src/analyze/analyze.dart
@@ -15,6 +15,9 @@ class AnalyzeCommand extends Command {
   String get name => 'analyze';
 
   @override
+  List<String> get aliases => ['analyse'];
+
+  @override
   void run() {
     final options = loadOptionsYaml();
     final parsedFiles = getFilesAndFolders(options, argResults);

--- a/lib/src/analyze/analyze.dart
+++ b/lib/src/analyze/analyze.dart
@@ -23,16 +23,11 @@ class AnalyzeCommand extends Command {
     final parsedFiles = getFilesAndFolders(options, argResults);
     final enabledRules = options.enabledRules();
 
-    final issuesFound = enabledRules.map((rule) {
-      final issues = rule.run(parsedFiles, options);
-
-      // Print a new line to separate issues from different rules
-      if (issues > 0) logError('');
-
-      return issues;
-    }).sum;
+    final issuesFound =
+        enabledRules.map((rule) => rule.run(parsedFiles, options)).sum;
 
     if (issuesFound > 0) {
+      logMessage('');
       logError(
         issuesFound == 1 ? '1 issue found' : '$issuesFound issues found',
       );

--- a/lib/src/utils/arb_parser/arb_parser.dart
+++ b/lib/src/utils/arb_parser/arb_parser.dart
@@ -37,8 +37,12 @@ ParsedArbFile parseArbFile(ArbFile file) {
       case JsonEventType.beginArray:
       case JsonEventType.endArray:
       case JsonEventType.arrayElement:
-        logError('${file.filepath}: ARB files must not contain arrays');
-        throw FormatException();
+        if (level == 0) {
+          logError(
+            '${file.filepath}: ARB files must not contain top-level arrays',
+          );
+          throw FormatException();
+        }
       case JsonEventType.beginObject:
         level++;
 

--- a/lib/src/utils/arb_parser/arb_parser.dart
+++ b/lib/src/utils/arb_parser/arb_parser.dart
@@ -37,7 +37,7 @@ ParsedArbFile parseArbFile(ArbFile file) {
       case JsonEventType.beginArray:
       case JsonEventType.endArray:
       case JsonEventType.arrayElement:
-        if (level == 0) {
+        if (level <= 1) {
           logError(
             '${file.filepath}: ARB files must not contain top-level arrays',
           );

--- a/lib/src/utils/extensions.dart
+++ b/lib/src/utils/extensions.dart
@@ -36,11 +36,11 @@ extension StringX on String {
 
   /// Covert regular key to an @-key
   String get toAtKey {
-    if (isAtKey) {
-      throw Exception('Key must not be an at-key');
-    }
     if (isLocaleDefinition) {
       throw Exception('Key must not be a locale definition');
+    }
+    if (isAtKey) {
+      return this;
     }
 
     return '@$this';

--- a/test/src/analyze/analyze_test.dart
+++ b/test/src/analyze/analyze_test.dart
@@ -52,6 +52,7 @@ void main() {
       '''
 ./strings_en.arb: file has duplicate key "appTitle"
 ./strings_en.arb: no @@locale key found
+
 2 issues found'''
           .trim(),
     );

--- a/test/src/utils/arb_parser/arb_parser_test.dart
+++ b/test/src/utils/arb_parser/arb_parser_test.dart
@@ -48,8 +48,54 @@ void main() {
     );
     expect(
       inMemoryLogger.output,
-      'strings_en.arb: ARB files must not contain arrays',
+      'strings_en.arb: ARB files must not contain top-level arrays',
     );
+  });
+
+  test('parseArbFile can parse placeholder array', () {
+    final tester = AppTester.create();
+    tester.populateFileSystem({
+      'strings_en.arb': '''
+{
+  "key": "Hi, {name}",
+  "@key": {
+    "description": "Greeting",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Hi, John",
+        "something": ["a", "b"]
+      }
+    }
+  }
+}
+''',
+    });
+
+    final parsedFile = parseArbFile(
+      ArbFile(
+        filepath: 'strings_en.arb',
+        locale: 'en',
+        isMainFile: true,
+      ),
+    );
+    expect(
+      parsedFile.content,
+      {
+        'key': 'Hi, {name}',
+        '@key': AtKeyMeta(
+          description: 'Greeting',
+          placeholders: [
+            AtKeyPlaceholder(
+              name: 'name',
+              type: 'String',
+              example: 'Hi, John',
+            ),
+          ],
+        ),
+      },
+    );
+    expect(inMemoryLogger.output, isEmpty);
   });
 
   test('parseArbFile can parse key meta', () {

--- a/test/src/utils/extensions_test.dart
+++ b/test/src/utils/extensions_test.dart
@@ -36,7 +36,7 @@ void main() {
     expect('key'.toAtKey, '@key');
     expect('key_1'.toAtKey, '@key_1');
     expect('keyOne'.toAtKey, '@keyOne');
-    expect(() => '@key'.toAtKey, throwsException);
+    expect('@key'.toAtKey, '@key');
     expect(() => '@@locale'.toAtKey, throwsException);
   });
 }


### PR DESCRIPTION
* Fix #8
* Accept `analyse` as an alias of `analyze`
* Allow non top-level arrays (found it in one of our ARB files)