### PR TITLE
Add option to ignore rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,25 @@ If this YAML file could not be found, default set of options is used. Consider c
   
   Check that all @-keys have corresponding key
 
+## Ignoring rules for individual keys
+
+Rules can be ignored for individual keys. Use `@@x-ignore` inside @-key body to list ignored list. For example, here all caps rules is ignored because this string is short and uses upper-case on purpose:
+
+```json
+{
+  "indicatorLost": "X",
+  "@indicatorLost": {
+    "description": "Indicates a failed attempt",
+    "@@x-ignore": "all_caps"
+  }
+}
+```
+
+Ignoring multiple rules can be done by listing all ignored rules:
+
+```json
+"@@x-ignore": ["all_caps", "naming_convention"]
+```
 
 ## Updating plurals rules
 

--- a/lib/src/analyze/analyze.dart
+++ b/lib/src/analyze/analyze.dart
@@ -39,7 +39,7 @@ class AnalyzeCommand extends Command {
 
     // final options = RebellionOptions.fromYaml(argResults, yamlOptions);
     final parsedFiles = getFilesAndFolders(options, argResults);
-    final enabledRules = options.enabledRules();
+    final enabledRules = options.enabledRules.map((r) => r.rule);
     final analyzerOptions = AnalyzerOptions.fromFiles(
       rebellionOptions: options,
       files: parsedFiles,

--- a/lib/src/analyze/rules/all_caps.dart
+++ b/lib/src/analyze/rules/all_caps.dart
@@ -9,7 +9,9 @@ import 'package:rebellion/src/message_parser/messages/message.dart';
 import 'package:rebellion/src/message_parser/messages/submessages/gender.dart';
 import 'package:rebellion/src/message_parser/messages/submessages/plural.dart';
 import 'package:rebellion/src/message_parser/messages/submessages/select.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
 import 'package:rebellion/src/utils/arb_parser/parsed_arb_file.dart';
+import 'package:rebellion/src/utils/extensions.dart';
 import 'package:rebellion/src/utils/logger.dart';
 
 // Regular expression to match all upper case letters. For example:
@@ -34,6 +36,11 @@ class AllCaps extends Rule {
 
       for (final key in keys) {
         final value = file.content[key];
+
+        final atKey = file.content[key.toAtKey];
+        if (atKey is AtKeyMeta && atKey.isRuleIgnored(RuleKey.allCaps)) {
+          continue;
+        }
 
         // Ignore unparsable strings, they're likely to be caught by
         // other checks like StringType or AtKeyType

--- a/lib/src/analyze/rules/empty_at_key.dart
+++ b/lib/src/analyze/rules/empty_at_key.dart
@@ -21,8 +21,14 @@ class EmptyAtKeys extends Rule {
 
         final value = file.content[key];
         if (value is AtKeyMeta) {
+          final atKey = file.content[key.toAtKey];
+          if (atKey is AtKeyMeta && atKey.isRuleIgnored(RuleKey.emptyAtKey)) {
+            continue;
+          }
+
           if ((value.description?.isEmpty ?? true) &&
-              value.placeholders.isEmpty) {
+              value.placeholders.isEmpty &&
+              (value.ignoredRulesRaw.isEmpty)) {
             issues++;
             logError('${file.file.filepath}: empty @-key "$key"');
           }

--- a/lib/src/analyze/rules/mandatory_key_description.dart
+++ b/lib/src/analyze/rules/mandatory_key_description.dart
@@ -25,6 +25,12 @@ class MandatoryKeyDescription extends Rule {
       for (final key in keys) {
         if (!key.isAtKey) continue;
 
+        final atKey = file.content[key.toAtKey];
+        if (atKey is AtKeyMeta &&
+            atKey.isRuleIgnored(RuleKey.mandatoryAtKeyDescription)) {
+          continue;
+        }
+
         final value = file.content[key];
         if (value is AtKeyMeta && (value.description?.isEmpty ?? true)) {
           issues++;

--- a/lib/src/analyze/rules/missing_placeholders.dart
+++ b/lib/src/analyze/rules/missing_placeholders.dart
@@ -48,6 +48,12 @@ class MissingPlaceholders extends Rule {
         final mainFileAtKey = mainFile.content[key.toAtKey];
         if (mainFileAtKey is! AtKeyMeta) continue;
 
+        final atKey = file.content[key.toAtKey];
+        if (atKey is AtKeyMeta &&
+            atKey.isRuleIgnored(RuleKey.missingPlaceholders)) {
+          continue;
+        }
+
         // Placeholders actually used in the string
         final mainKeyUsedPlaceholders =
             getAllVariableSubstitutions(mainFileContent).toSet();

--- a/lib/src/analyze/rules/missing_plurals.dart
+++ b/lib/src/analyze/rules/missing_plurals.dart
@@ -3,6 +3,7 @@ import 'package:rebellion/src/analyze/rules/rule.dart';
 import 'package:rebellion/src/generated/plural_rules.dart';
 import 'package:rebellion/src/message_parser/message_parser.dart';
 import 'package:rebellion/src/message_parser/messages/submessages/plural.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
 import 'package:rebellion/src/utils/arb_parser/parsed_arb_file.dart';
 import 'package:rebellion/src/utils/extensions.dart';
 import 'package:rebellion/src/utils/logger.dart';
@@ -22,6 +23,11 @@ class MissingPlurals extends Rule {
       for (final key in file.keys) {
         if (key.isAtKey) continue;
         if (key.isLocaleDefinition) continue;
+
+        final atKey = file.content[key.toAtKey];
+        if (atKey is AtKeyMeta && atKey.isRuleIgnored(RuleKey.missingPlurals)) {
+          continue;
+        }
 
         final value = file.content[key];
         // Ignore unparsable strings, they're likely to be caused by

--- a/lib/src/analyze/rules/naming_convention.dart
+++ b/lib/src/analyze/rules/naming_convention.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:rebellion/src/analyze/analyzer_options.dart';
 import 'package:rebellion/src/analyze/rules/rule.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
 import 'package:rebellion/src/utils/arb_parser/parsed_arb_file.dart';
 import 'package:rebellion/src/utils/extensions.dart';
 import 'package:rebellion/src/utils/logger.dart';
@@ -55,6 +56,12 @@ class NamingConventionRule extends Rule {
     final convention = options.rebellionOptions.namingConvention;
     for (final file in files) {
       for (final key in file.keys) {
+        final atKey = file.content[key.toAtKey];
+        if (atKey is AtKeyMeta &&
+            atKey.isRuleIgnored(RuleKey.namingConvention)) {
+          continue;
+        }
+
         if (convention.hasMatch(key) == false) {
           issues++;
           logError(

--- a/lib/src/analyze/rules/redundant_at_key.dart
+++ b/lib/src/analyze/rules/redundant_at_key.dart
@@ -1,5 +1,6 @@
 import 'package:rebellion/src/analyze/analyzer_options.dart';
 import 'package:rebellion/src/analyze/rules/rule.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
 import 'package:rebellion/src/utils/arb_parser/parsed_arb_file.dart';
 import 'package:rebellion/src/utils/extensions.dart';
 import 'package:rebellion/src/utils/logger.dart';
@@ -18,6 +19,11 @@ class RedundantAtKey extends Rule {
 
       for (final key in file.keys) {
         if (!key.isAtKey) continue;
+
+        final atKey = file.content[key.toAtKey];
+        if (atKey is AtKeyMeta && atKey.isRuleIgnored(RuleKey.redundantAtKey)) {
+          continue;
+        }
 
         issues++;
         logError(

--- a/lib/src/analyze/rules/redundant_translations.dart
+++ b/lib/src/analyze/rules/redundant_translations.dart
@@ -1,5 +1,6 @@
 import 'package:rebellion/src/analyze/analyzer_options.dart';
 import 'package:rebellion/src/analyze/rules/rule.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
 import 'package:rebellion/src/utils/arb_parser/parsed_arb_file.dart';
 import 'package:rebellion/src/utils/extensions.dart';
 import 'package:rebellion/src/utils/logger.dart';
@@ -29,6 +30,12 @@ class RedundantTranslations extends Rule {
       );
 
       for (final key in redundantKeys) {
+        final atKey = file.content[key.toAtKey];
+        if (atKey is AtKeyMeta &&
+            atKey.isRuleIgnored(RuleKey.redundantTranslations)) {
+          continue;
+        }
+
         issues++;
         logError(
           '${file.file.filepath}: redundant translation "$key"',

--- a/lib/src/analyze/rules/rule.dart
+++ b/lib/src/analyze/rules/rule.dart
@@ -1,4 +1,20 @@
+import 'package:collection/collection.dart';
 import 'package:rebellion/src/analyze/analyzer_options.dart';
+import 'package:rebellion/src/analyze/rules/all_caps.dart';
+import 'package:rebellion/src/analyze/rules/at_key_type.dart';
+import 'package:rebellion/src/analyze/rules/duplicate_keys.dart';
+import 'package:rebellion/src/analyze/rules/empty_at_key.dart';
+import 'package:rebellion/src/analyze/rules/locale_definition.dart';
+import 'package:rebellion/src/analyze/rules/mandatory_key_description.dart';
+import 'package:rebellion/src/analyze/rules/missing_placeholders.dart';
+import 'package:rebellion/src/analyze/rules/missing_plurals.dart';
+import 'package:rebellion/src/analyze/rules/missing_translations.dart';
+import 'package:rebellion/src/analyze/rules/naming_convention.dart';
+import 'package:rebellion/src/analyze/rules/redundant_at_key.dart';
+import 'package:rebellion/src/analyze/rules/redundant_translations.dart';
+import 'package:rebellion/src/analyze/rules/sanity_check.dart';
+import 'package:rebellion/src/analyze/rules/string_type.dart';
+import 'package:rebellion/src/analyze/rules/unused_at_key.dart';
 import 'package:rebellion/src/utils/arb_parser/parsed_arb_file.dart';
 
 /// Simple flag-like rule that can be enabled or disabled
@@ -8,4 +24,91 @@ abstract class Rule {
 
   /// Check [files] and return number of found issues
   int run(List<ParsedArbFile> files, AnalyzerOptions options);
+}
+
+/// Enum of all available rules
+enum RuleKey {
+  /// Perform some checks to ensure data is parsed correctly
+  sanityCheck('sanityCheck', true),
+
+  /// Check that all keys are in all caps
+  allCaps('all_caps', true),
+
+  /// Check that all values are strings
+  stringType('string_type', true),
+
+  /// Check that all keys start with @
+  atKeyType('at_key_type', true),
+
+  /// Check for duplicated keys
+  duplicatedKeys('duplicated_keys', true),
+
+  /// Check for empty @-keys
+  emptyAtKey('empty_at_key', true),
+
+  /// Check that all files have a locale definition
+  localeDefinition('locale_definition', true),
+
+  /// Check that all @-keys have a description
+  mandatoryAtKeyDescription('mandatory_at_key_description', false),
+
+  /// Check for missing placeholders
+  missingPlaceholders('missing_placeholders', true),
+
+  /// Check for missing plurals
+  missingPlurals('missing_plurals', true),
+
+  /// Check for missing translations
+  missingTranslations('missing_translations', true),
+
+  /// Check for redundant @-keys
+  redundantAtKey('redundant_at_key', true),
+
+  /// Check for redundant translations
+  redundantTranslations('redundant_translations', true),
+
+  /// Check for unused @-keys
+  unusedAtKey('unused_at_key', true),
+
+  /// Check that keys are camelCase or snake_case
+  namingConvention('naming_convention', true);
+
+  /// Key that represents the rule. Used in YAML configuration file and when
+  /// enabling/disabling rules in ARB files
+  final String key;
+
+  /// Whether the rule is enabled by default
+  final bool isEnabledByDefault;
+
+  /// Default constructor
+  const RuleKey(this.key, this.isEnabledByDefault);
+
+  /// Get [Rule] instance corresponding to this [RuleKey]
+  Rule get rule {
+    return switch (this) {
+      RuleKey.sanityCheck => SanityCheck(),
+      RuleKey.allCaps => AllCaps(),
+      RuleKey.stringType => StringType(),
+      RuleKey.atKeyType => AtKeyType(),
+      RuleKey.duplicatedKeys => DuplicatedKeys(),
+      RuleKey.emptyAtKey => EmptyAtKeys(),
+      RuleKey.localeDefinition => LocaleDefinitionPresent(),
+      RuleKey.mandatoryAtKeyDescription => MandatoryKeyDescription(),
+      RuleKey.missingPlaceholders => MissingPlaceholders(),
+      RuleKey.missingPlurals => MissingPlurals(),
+      RuleKey.missingTranslations => MissingTranslations(),
+      RuleKey.redundantAtKey => RedundantAtKey(),
+      RuleKey.redundantTranslations => RedundantTranslations(),
+      RuleKey.unusedAtKey => UnusedAtKey(),
+      RuleKey.namingConvention => NamingConventionRule(),
+    };
+  }
+
+  /// Get [RuleKey] from [key] string
+  static RuleKey? fromKey(String key) =>
+      RuleKey.values.firstWhereOrNull((e) => e.key == key);
+
+  /// Get all rules that are enabled by default
+  static Set<RuleKey> get defaultRules =>
+      RuleKey.values.where((e) => e.isEnabledByDefault).toSet();
 }

--- a/lib/src/analyze/rules/sanity_check.dart
+++ b/lib/src/analyze/rules/sanity_check.dart
@@ -1,0 +1,39 @@
+import 'package:rebellion/src/analyze/analyzer_options.dart';
+import 'package:rebellion/src/analyze/rules/rule.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
+import 'package:rebellion/src/utils/arb_parser/parsed_arb_file.dart';
+import 'package:rebellion/src/utils/extensions.dart';
+import 'package:rebellion/src/utils/logger.dart';
+
+/// Perform some checks to ensure data is parsed correctly and all expected
+/// properties and options are present
+class SanityCheck extends Rule {
+  @override
+  int run(List<ParsedArbFile> files, AnalyzerOptions options) {
+    int issues = 0;
+
+    for (final file in files) {
+      final keys = file.keys;
+      for (final key in keys) {
+        if (key.isAtKey) {
+          final atKeyContent = file.content[key];
+          if (atKeyContent is AtKeyMeta) {
+            // Check misspelled and unknown ignored rule names
+            final unknownIgnoredRules = atKeyContent.ignoredRulesRaw
+                .where((key) => RuleKey.fromKey(key) == null);
+            if (unknownIgnoredRules.isNotEmpty) {
+              for (final rule in unknownIgnoredRules) {
+                issues++;
+                logError(
+                  '${file.file.filepath}: key "$key" contains unknown ignored rule: "$rule"',
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/src/analyze/rules/unused_at_key.dart
+++ b/lib/src/analyze/rules/unused_at_key.dart
@@ -1,5 +1,6 @@
 import 'package:rebellion/src/analyze/analyzer_options.dart';
 import 'package:rebellion/src/analyze/rules/rule.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
 import 'package:rebellion/src/utils/arb_parser/parsed_arb_file.dart';
 import 'package:rebellion/src/utils/extensions.dart';
 import 'package:rebellion/src/utils/logger.dart';
@@ -17,6 +18,11 @@ class UnusedAtKey extends Rule {
       final keys = file.keys;
       for (final key in keys) {
         if (!key.isAtKey) continue;
+
+        final atKey = file.content[key.toAtKey];
+        if (atKey is AtKeyMeta && atKey.isRuleIgnored(RuleKey.unusedAtKey)) {
+          continue;
+        }
 
         final correspondingKey = key.atKeyToRegularKey;
         if (!keys.contains(correspondingKey)) {

--- a/lib/src/utils/args.dart
+++ b/lib/src/utils/args.dart
@@ -18,53 +18,16 @@ abstract class CliArgs {
   static const sortingParam = 'sorting';
 }
 
-/// List of all available YAML arguments
+/// List of all available YAML options
+///
+/// [Rules] contains all available rule names that can be used in YAML
 abstract class YamlArgs {
-  /// All caps rule name
-  static const allCaps = 'all_caps';
-
-  /// At key type rule name
-  static const stringType = 'string_type';
-
-  /// Duplicated keys rule name
-  static const atKeyType = 'at_key_type';
-
-  /// Empty at key rule name
-  static const duplicatedKeys = 'duplicated_keys';
-
-  /// Empty at key rule name
-  static const emptyAtKey = 'empty_at_key';
-
-  /// File name rule name
-  static const localeDefinition = 'locale_definition';
-
-  /// Mandatory at key description rule name
-  static const mandatoryAtKeyDescription = 'mandatory_at_key_description';
-
-  /// Mandatory at key rule name
-  static const missingPlaceholders = 'missing_placeholders';
-
-  /// Missing plurals rule name
-  static const missingPlurals = 'missing_plurals';
-
-  /// Missing translations rule name
-  static const missingTranslations = 'missing_translations';
-
-  /// Redundant at key rule name
-  static const redundantAtKey = 'redundant_at_key';
-
-  /// Redundant translations rule name
-  static const redundantTranslations = 'redundant_translations';
-
-  /// Unused at key rule name
-  static const unusedAtKey = 'unused_at_key';
-
-  /// Main locale option name
+  /// Option to set main locale
   static const mainLocale = 'main_locale';
 
-  /// Naming convention option name
+  /// Option to set naming convention
   static const namingConvention = 'naming_convention';
 
-  /// Sorting option name
+  /// Option to set sorting
   static const sorting = 'sorting';
 }

--- a/lib/src/utils/extensions.dart
+++ b/lib/src/utils/extensions.dart
@@ -34,15 +34,10 @@ extension StringX on String {
     }
   }
 
-  /// Covert regular key to an @-key
+  /// Covert a key to an @-key
   String get toAtKey {
-    if (isLocaleDefinition) {
-      throw Exception('Key must not be a locale definition');
-    }
-    if (isAtKey) {
-      return this;
-    }
-
+    if (isAtKey) return this;
+    if (isLocaleDefinition) return this;
     return '@$this';
   }
 }

--- a/lib/src/utils/rebellion_options.dart
+++ b/lib/src/utils/rebellion_options.dart
@@ -1,21 +1,8 @@
 import 'package:args/args.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
-import 'package:rebellion/src/analyze/rules/all_caps.dart';
-import 'package:rebellion/src/analyze/rules/at_key_type.dart';
-import 'package:rebellion/src/analyze/rules/duplicate_keys.dart';
-import 'package:rebellion/src/analyze/rules/empty_at_key.dart';
-import 'package:rebellion/src/analyze/rules/locale_definition.dart';
-import 'package:rebellion/src/analyze/rules/mandatory_key_description.dart';
-import 'package:rebellion/src/analyze/rules/missing_placeholders.dart';
-import 'package:rebellion/src/analyze/rules/missing_plurals.dart';
-import 'package:rebellion/src/analyze/rules/missing_translations.dart';
 import 'package:rebellion/src/analyze/rules/naming_convention.dart';
-import 'package:rebellion/src/analyze/rules/redundant_at_key.dart';
-import 'package:rebellion/src/analyze/rules/redundant_translations.dart';
 import 'package:rebellion/src/analyze/rules/rule.dart';
-import 'package:rebellion/src/analyze/rules/string_type.dart';
-import 'package:rebellion/src/analyze/rules/unused_at_key.dart';
 import 'package:rebellion/src/sort/sort.dart';
 import 'package:rebellion/src/utils/args.dart';
 import 'package:rebellion/src/utils/file_reader.dart';
@@ -25,49 +12,13 @@ import 'package:yaml/yaml.dart';
 @visibleForTesting
 const configFilename = 'rebellion_options.yaml';
 
-/// Options for the rebellion tool
+/// Options for the rebellion tool. This includes enabled rules, main locale,
+/// naming convention and sorting of keys.
+///
+/// This class represents the YAML configuration file and CLI arguments.
 class RebellionOptions with EquatableMixin {
-  /// True if [AllCaps] rule is enabled
-  final bool allCapsRuleEnabled;
-
-  /// True if [StringType] rule is enabled
-  final bool stringTypeRuleEnabled;
-
-  /// True if [AtKeyType] rule is enabled
-  final bool atKeyTypeRuleEnabled;
-
-  /// True if [DuplicatedKeys] rule is enabled
-  final bool duplicatedKeysRuleEnabled;
-
-  /// True if [EmptyAtKeys] rule is enabled
-  final bool emptyAtKeyRuleEnabled;
-
-  /// True if [LocaleDefinitionPresent] rule is enabled
-  final bool localeDefinitionRuleEnabled;
-
-  /// True if [MandatoryKeyDescription] rule is enabled
-  final bool mandatoryAtKeyDescriptionRuleEnabled;
-
-  /// True if [MissingPlaceholders] rule is enabled
-  final bool missingPlaceholdersRuleEnabled;
-
-  /// True if [MissingPlurals] rule is enabled
-  final bool missingPluralsRuleEnabled;
-
-  /// True if [MissingTranslations] rule is enabled
-  final bool missingTranslationsRuleEnabled;
-
-  /// True if [NamingConventionRule] rule is enabled
-  final bool namingConventionRuleEnabled;
-
-  /// True if [RedundantAtKey] rule is enabled
-  final bool redundantAtKeyRuleEnabled;
-
-  /// True if [RedundantTranslations] rule is enabled
-  final bool redundantTranslationsRuleEnabled;
-
-  /// True if [UnusedAtKey] rule is enabled
-  final bool unusedAtKeyRuleEnabled;
+  /// List of enabled rules
+  final Set<RuleKey> enabledRules;
 
   /// Default locale of the project
   final String mainLocale;
@@ -80,40 +31,12 @@ class RebellionOptions with EquatableMixin {
 
   /// Default constructor
   @visibleForTesting
-  const RebellionOptions({
-    required bool? allCapsRuleEnabled,
-    required bool? stringTypeRuleEnabled,
-    required bool? atKeyTypeRuleEnabled,
-    required bool? duplicatedKeysRuleEnabled,
-    required bool? emptyAtKeyRuleEnabled,
-    required bool? localeDefinitionRuleEnabled,
-    required bool? mandatoryAtKeyDescriptionRuleEnabled,
-    required bool? missingPlaceholdersRuleEnabled,
-    required bool? missingPluralsRuleEnabled,
-    required bool? missingTranslationsRuleEnabled,
-    required bool? namingConventionRuleEnabled,
-    required bool? redundantAtKeyRuleEnabled,
-    required bool? redundantTranslationsRuleEnabled,
-    required bool? unusedAtKeyRuleEnabled,
+  RebellionOptions({
+    required Set<RuleKey>? enabledRules,
     required String? mainLocale,
     required NamingConvention? namingConvention,
     required Sorting? sorting,
-  })  : allCapsRuleEnabled = allCapsRuleEnabled ?? true,
-        stringTypeRuleEnabled = stringTypeRuleEnabled ?? true,
-        atKeyTypeRuleEnabled = atKeyTypeRuleEnabled ?? true,
-        duplicatedKeysRuleEnabled = duplicatedKeysRuleEnabled ?? true,
-        emptyAtKeyRuleEnabled = emptyAtKeyRuleEnabled ?? true,
-        localeDefinitionRuleEnabled = localeDefinitionRuleEnabled ?? true,
-        mandatoryAtKeyDescriptionRuleEnabled =
-            mandatoryAtKeyDescriptionRuleEnabled ?? false,
-        missingPlaceholdersRuleEnabled = missingPlaceholdersRuleEnabled ?? true,
-        missingPluralsRuleEnabled = missingPluralsRuleEnabled ?? true,
-        missingTranslationsRuleEnabled = missingTranslationsRuleEnabled ?? true,
-        namingConventionRuleEnabled = namingConventionRuleEnabled ?? true,
-        redundantAtKeyRuleEnabled = redundantAtKeyRuleEnabled ?? true,
-        redundantTranslationsRuleEnabled =
-            redundantTranslationsRuleEnabled ?? true,
-        unusedAtKeyRuleEnabled = unusedAtKeyRuleEnabled ?? true,
+  })  : enabledRules = enabledRules ?? RuleKey.defaultRules,
         mainLocale = mainLocale ?? defaultMainLocale,
         namingConvention = namingConvention ?? NamingConvention.camel,
         sorting = sorting ?? Sorting.alphabetical;
@@ -121,20 +44,7 @@ class RebellionOptions with EquatableMixin {
   /// Default empty constructor
   factory RebellionOptions.empty() {
     return RebellionOptions(
-      allCapsRuleEnabled: null,
-      stringTypeRuleEnabled: null,
-      atKeyTypeRuleEnabled: null,
-      duplicatedKeysRuleEnabled: null,
-      emptyAtKeyRuleEnabled: null,
-      localeDefinitionRuleEnabled: null,
-      mandatoryAtKeyDescriptionRuleEnabled: null,
-      missingPlaceholdersRuleEnabled: null,
-      missingPluralsRuleEnabled: null,
-      missingTranslationsRuleEnabled: null,
-      namingConventionRuleEnabled: null,
-      redundantAtKeyRuleEnabled: null,
-      redundantTranslationsRuleEnabled: null,
-      unusedAtKeyRuleEnabled: null,
+      enabledRules: null,
       mainLocale: null,
       namingConvention: null,
       sorting: null,
@@ -145,20 +55,7 @@ class RebellionOptions with EquatableMixin {
   factory RebellionOptions.fromCliArguments(ArgResults? argResults) {
     return RebellionOptions(
       mainLocale: argResults?.option(CliArgs.mainLocaleParam),
-      allCapsRuleEnabled: null,
-      stringTypeRuleEnabled: null,
-      atKeyTypeRuleEnabled: null,
-      duplicatedKeysRuleEnabled: null,
-      emptyAtKeyRuleEnabled: null,
-      localeDefinitionRuleEnabled: null,
-      mandatoryAtKeyDescriptionRuleEnabled: null,
-      missingPlaceholdersRuleEnabled: null,
-      missingPluralsRuleEnabled: null,
-      missingTranslationsRuleEnabled: null,
-      namingConventionRuleEnabled: null,
-      redundantAtKeyRuleEnabled: null,
-      redundantTranslationsRuleEnabled: null,
-      unusedAtKeyRuleEnabled: null,
+      enabledRules: null,
       namingConvention: null,
       sorting: null,
     );
@@ -174,28 +71,17 @@ class RebellionOptions with EquatableMixin {
     final fileContent = fileReader.readFile(configFilename);
     final yaml = loadYaml(fileContent) as YamlMap;
 
-    final rules = yaml.nodes['rules'] as YamlList?;
+    final rules = yaml.nodes['rules'] as YamlList? ?? const [];
     final options = yaml.nodes['options'] as YamlMap?;
 
+    final enabledRules = {
+      // Always include sanity check as first rule
+      RuleKey.sanityCheck,
+      ...rules.map((key) => RuleKey.fromKey(key)).nonNulls,
+    };
+
     return RebellionOptions(
-      allCapsRuleEnabled: rules?.contains(YamlArgs.allCaps),
-      stringTypeRuleEnabled: rules?.contains(YamlArgs.stringType),
-      atKeyTypeRuleEnabled: rules?.contains(YamlArgs.atKeyType),
-      duplicatedKeysRuleEnabled: rules?.contains(YamlArgs.duplicatedKeys),
-      emptyAtKeyRuleEnabled: rules?.contains(YamlArgs.emptyAtKey),
-      localeDefinitionRuleEnabled: rules?.contains(YamlArgs.localeDefinition),
-      mandatoryAtKeyDescriptionRuleEnabled:
-          rules?.contains(YamlArgs.mandatoryAtKeyDescription),
-      missingPlaceholdersRuleEnabled:
-          rules?.contains(YamlArgs.missingPlaceholders),
-      missingPluralsRuleEnabled: rules?.contains(YamlArgs.missingPlurals),
-      missingTranslationsRuleEnabled:
-          rules?.contains(YamlArgs.missingTranslations),
-      namingConventionRuleEnabled: rules?.contains(YamlArgs.namingConvention),
-      redundantAtKeyRuleEnabled: rules?.contains(YamlArgs.redundantAtKey),
-      redundantTranslationsRuleEnabled:
-          rules?.contains(YamlArgs.redundantTranslations),
-      unusedAtKeyRuleEnabled: rules?.contains(YamlArgs.unusedAtKey),
+      enabledRules: enabledRules,
       mainLocale: options?[YamlArgs.mainLocale] as String?,
       namingConvention: NamingConvention.fromOptionName(
         options?[YamlArgs.namingConvention] as String?,
@@ -204,42 +90,9 @@ class RebellionOptions with EquatableMixin {
     );
   }
 
-  /// Get a list of enabled rules
-  List<Rule> enabledRules() {
-    return <Rule>[
-      if (stringTypeRuleEnabled) const StringType(),
-      if (atKeyTypeRuleEnabled) const AtKeyType(),
-      if (allCapsRuleEnabled) const AllCaps(),
-      if (duplicatedKeysRuleEnabled) const DuplicatedKeys(),
-      if (emptyAtKeyRuleEnabled) const EmptyAtKeys(),
-      if (localeDefinitionRuleEnabled) const LocaleDefinitionPresent(),
-      if (mandatoryAtKeyDescriptionRuleEnabled) const MandatoryKeyDescription(),
-      if (missingPlaceholdersRuleEnabled) const MissingPlaceholders(),
-      if (missingPluralsRuleEnabled) const MissingPlurals(),
-      if (missingTranslationsRuleEnabled) const MissingTranslations(),
-      if (redundantAtKeyRuleEnabled) const RedundantAtKey(),
-      if (redundantTranslationsRuleEnabled) const RedundantTranslations(),
-      if (unusedAtKeyRuleEnabled) const UnusedAtKey(),
-      if (namingConventionRuleEnabled) const NamingConventionRule(),
-    ];
-  }
-
   @override
   List<Object?> get props => [
-        allCapsRuleEnabled,
-        stringTypeRuleEnabled,
-        atKeyTypeRuleEnabled,
-        duplicatedKeysRuleEnabled,
-        emptyAtKeyRuleEnabled,
-        localeDefinitionRuleEnabled,
-        mandatoryAtKeyDescriptionRuleEnabled,
-        missingPlaceholdersRuleEnabled,
-        missingPluralsRuleEnabled,
-        missingTranslationsRuleEnabled,
-        namingConventionRuleEnabled,
-        redundantAtKeyRuleEnabled,
-        redundantTranslationsRuleEnabled,
-        unusedAtKeyRuleEnabled,
+        enabledRules,
         mainLocale,
         namingConvention,
         sorting,
@@ -254,52 +107,13 @@ class RebellionOptions with EquatableMixin {
 
   /// Copy the current [RebellionOptions] with new values
   RebellionOptions copyWith({
-    bool? allCapsRuleEnabled,
-    bool? stringTypeRuleEnabled,
-    bool? atKeyTypeRuleEnabled,
-    bool? duplicatedKeysRuleEnabled,
-    bool? emptyAtKeyRuleEnabled,
-    bool? localeDefinitionRuleEnabled,
-    bool? mandatoryAtKeyDescriptionRuleEnabled,
-    bool? missingPlaceholdersRuleEnabled,
-    bool? missingPluralsRuleEnabled,
-    bool? missingTranslationsRuleEnabled,
-    bool? namingConventionRuleEnabled,
-    bool? redundantAtKeyRuleEnabled,
-    bool? redundantTranslationsRuleEnabled,
-    bool? unusedAtKeyRuleEnabled,
+    Set<RuleKey>? enabledRules,
     String? mainLocale,
     NamingConvention? namingConvention,
     Sorting? sorting,
   }) {
     return RebellionOptions(
-      allCapsRuleEnabled: allCapsRuleEnabled ?? this.allCapsRuleEnabled,
-      stringTypeRuleEnabled:
-          stringTypeRuleEnabled ?? this.stringTypeRuleEnabled,
-      atKeyTypeRuleEnabled: atKeyTypeRuleEnabled ?? this.atKeyTypeRuleEnabled,
-      duplicatedKeysRuleEnabled:
-          duplicatedKeysRuleEnabled ?? this.duplicatedKeysRuleEnabled,
-      emptyAtKeyRuleEnabled:
-          emptyAtKeyRuleEnabled ?? this.emptyAtKeyRuleEnabled,
-      localeDefinitionRuleEnabled:
-          localeDefinitionRuleEnabled ?? this.localeDefinitionRuleEnabled,
-      mandatoryAtKeyDescriptionRuleEnabled:
-          mandatoryAtKeyDescriptionRuleEnabled ??
-              this.mandatoryAtKeyDescriptionRuleEnabled,
-      missingPlaceholdersRuleEnabled:
-          missingPlaceholdersRuleEnabled ?? this.missingPlaceholdersRuleEnabled,
-      missingPluralsRuleEnabled:
-          missingPluralsRuleEnabled ?? this.missingPluralsRuleEnabled,
-      missingTranslationsRuleEnabled:
-          missingTranslationsRuleEnabled ?? this.missingTranslationsRuleEnabled,
-      namingConventionRuleEnabled:
-          namingConventionRuleEnabled ?? this.namingConventionRuleEnabled,
-      redundantAtKeyRuleEnabled:
-          redundantAtKeyRuleEnabled ?? this.redundantAtKeyRuleEnabled,
-      redundantTranslationsRuleEnabled: redundantTranslationsRuleEnabled ??
-          this.redundantTranslationsRuleEnabled,
-      unusedAtKeyRuleEnabled:
-          unusedAtKeyRuleEnabled ?? this.unusedAtKeyRuleEnabled,
+      enabledRules: enabledRules ?? this.enabledRules,
       mainLocale: mainLocale ?? this.mainLocale,
       namingConvention: namingConvention ?? this.namingConvention,
       sorting: sorting ?? this.sorting,

--- a/test/src/analyze/analyze_test.dart
+++ b/test/src/analyze/analyze_test.dart
@@ -7,6 +7,10 @@ import '../../infrastructure/app_tester.dart';
 import '../../infrastructure/logger.dart';
 
 void main() {
+  setUp(() {
+    inMemoryLogger.clear();
+  });
+
   test('Prints a message when no files and folders specified', () async {
     AppTester.create();
 

--- a/test/src/analyze/rules/all_caps_test.dart
+++ b/test/src/analyze/rules/all_caps_test.dart
@@ -1,5 +1,6 @@
 import 'package:rebellion/src/analyze/analyzer_options.dart';
 import 'package:rebellion/src/analyze/rules/all_caps.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
 import 'package:rebellion/src/utils/rebellion_options.dart';
 import 'package:test/test.dart';
 
@@ -133,5 +134,31 @@ filepath key key: all caps string in case "other"
     expect(AllCaps.isAllCapsString('ФУБАР'), isTrue);
     expect(AllCaps.isAllCapsString('😉'), isFalse);
     expect(AllCaps.isAllCapsString('☝🏾'), isFalse);
+  });
+
+  test('Rule can be ignored', () {
+    var issues = AllCaps().run(
+      [
+        createFile(
+          values: {
+            'key1': 'ABC',
+            'key2': 'DEF',
+            '@key2': AtKeyMeta(
+              description: null,
+              placeholders: [],
+              ignoredRulesRaw: ['all_caps'],
+            ),
+          },
+        ),
+      ],
+      options,
+    );
+    expect(issues, 1);
+    expect(
+        inMemoryLogger.output,
+        '''
+filepath: all caps string key "key1"
+'''
+            .trim());
   });
 }

--- a/test/src/analyze/rules/at_key_type_test.dart
+++ b/test/src/analyze/rules/at_key_type_test.dart
@@ -56,6 +56,7 @@ void main() {
           '@key': AtKeyMeta(
             description: 'Key description',
             placeholders: [],
+            ignoredRulesRaw: [],
           ),
         },
       ),

--- a/test/src/analyze/rules/empty_at_key_test.dart
+++ b/test/src/analyze/rules/empty_at_key_test.dart
@@ -9,14 +9,14 @@ import '../../../infrastructure/logger.dart';
 import '../../../infrastructure/test_arb_files.dart';
 
 void main() {
+  final analyzerOptions = AnalyzerOptions(
+    rebellionOptions: RebellionOptions.empty(),
+    isSingleFile: true,
+    containsMainFile: true,
+  );
+
   test('EmptyAtKeys checks @-keys without description', () async {
     AppTester.create();
-
-    final analyzerOptions = AnalyzerOptions(
-      rebellionOptions: RebellionOptions.empty(),
-      isSingleFile: true,
-      containsMainFile: true,
-    );
 
     // No @-keys - no error
     var issues = EmptyAtKeys().run(
@@ -38,6 +38,7 @@ void main() {
             '@key': AtKeyMeta(
               description: 'Key description',
               placeholders: [],
+              ignoredRulesRaw: [],
             ),
           },
         ),
@@ -57,6 +58,7 @@ void main() {
             '@key': AtKeyMeta(
               description: null,
               placeholders: [],
+              ignoredRulesRaw: [],
             ),
           },
         ),
@@ -79,6 +81,7 @@ void main() {
             '@key': AtKeyMeta(
               description: '',
               placeholders: [],
+              ignoredRulesRaw: [],
             ),
           },
         ),
@@ -100,6 +103,7 @@ void main() {
             'key': 'Issues: {count}',
             '@key': AtKeyMeta(
               description: null,
+              ignoredRulesRaw: [],
               placeholders: [
                 AtKeyPlaceholder(
                   name: 'count',
@@ -107,6 +111,26 @@ void main() {
                   example: null,
                 ),
               ],
+            ),
+          },
+        ),
+      ],
+      analyzerOptions,
+    );
+    expect(issues, 0);
+    expect(inMemoryLogger.output, isEmpty);
+  });
+
+  test('Rule can be ignored', () {
+    var issues = EmptyAtKeys().run(
+      [
+        createFile(
+          values: {
+            'key': 'Abc',
+            '@key': AtKeyMeta(
+              description: null,
+              placeholders: [],
+              ignoredRulesRaw: ['empty_at_key'],
             ),
           },
         ),

--- a/test/src/analyze/rules/mandatory_key_description_test.dart
+++ b/test/src/analyze/rules/mandatory_key_description_test.dart
@@ -8,16 +8,21 @@ import 'package:test/test.dart';
 
 import '../../../infrastructure/app_tester.dart';
 import '../../../infrastructure/logger.dart';
+import '../../../infrastructure/test_arb_files.dart';
 
 void main() {
+  final analyzerOptions = AnalyzerOptions(
+    rebellionOptions: RebellionOptions.empty(),
+    isSingleFile: true,
+    containsMainFile: true,
+  );
+
+  setUp(() {
+    inMemoryLogger.clear();
+  });
+
   test('MandatoryKeyDescription checks that key description is present', () {
     AppTester.create();
-
-    final analyzerOptions = AnalyzerOptions(
-      rebellionOptions: RebellionOptions.empty(),
-      isSingleFile: true,
-      containsMainFile: true,
-    );
 
     // Key description is present
     var issues = MandatoryKeyDescription().run(
@@ -33,6 +38,7 @@ void main() {
             '@key': AtKeyMeta(
               description: 'Key description',
               placeholders: [],
+              ignoredRulesRaw: [],
             ),
           },
           rawKeys: ['key', '@key'],
@@ -58,6 +64,7 @@ void main() {
             '@key': AtKeyMeta(
               description: null,
               placeholders: [],
+              ignoredRulesRaw: [],
             ),
           },
           rawKeys: ['key', '@key'],
@@ -70,5 +77,25 @@ void main() {
       inMemoryLogger.output,
       'filepath: @-key "@key" must have a description',
     );
+  });
+
+  test('Rule can be ignored', () {
+    var issues = MandatoryKeyDescription().run(
+      [
+        createFile(
+          values: {
+            'key': 'Abc',
+            '@key': AtKeyMeta(
+              description: null,
+              placeholders: [],
+              ignoredRulesRaw: ['mandatory_at_key_description'],
+            ),
+          },
+        ),
+      ],
+      analyzerOptions,
+    );
+    expect(issues, 0);
+    expect(inMemoryLogger.output, isEmpty);
   });
 }

--- a/test/src/analyze/rules/missing_plurals_test.dart
+++ b/test/src/analyze/rules/missing_plurals_test.dart
@@ -1,5 +1,6 @@
 import 'package:rebellion/src/analyze/analyzer_options.dart';
 import 'package:rebellion/src/analyze/rules/missing_plurals.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
 import 'package:rebellion/src/utils/rebellion_options.dart';
 import 'package:test/test.dart';
 
@@ -193,5 +194,29 @@ strings_zh.arb key "key" contains a redundant plural value "one"
 strings_ru.arb key "key" contains a redundant plural value "two"
 '''
             .trim());
+  });
+
+  test('Rule can be ignored', () {
+    final issues = MissingPlurals().run(
+      [
+        createFile(
+          filepath: 'strings_en.arb',
+          isMainFile: true,
+          locale: 'en',
+          values: {
+            // Missing 'other'
+            'key': '{count, plural, one{one day}}}',
+            "@key": AtKeyMeta(
+              description: null,
+              placeholders: [],
+              ignoredRulesRaw: ['missing_plurals'],
+            ),
+          },
+        ),
+      ],
+      analyzerOptions,
+    );
+    expect(issues, 0);
+    expect(inMemoryLogger.output, isEmpty);
   });
 }

--- a/test/src/analyze/rules/redundant_at_key_test.dart
+++ b/test/src/analyze/rules/redundant_at_key_test.dart
@@ -1,5 +1,6 @@
 import 'package:rebellion/src/analyze/analyzer_options.dart';
 import 'package:rebellion/src/analyze/rules/redundant_at_key.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
 import 'package:rebellion/src/utils/rebellion_options.dart';
 import 'package:test/test.dart';
 
@@ -8,16 +9,18 @@ import '../../../infrastructure/logger.dart';
 import '../../../infrastructure/test_arb_files.dart';
 
 void main() {
+  final analyzerOptions = AnalyzerOptions(
+    rebellionOptions: RebellionOptions.empty(),
+    isSingleFile: false,
+    containsMainFile: true,
+  );
+
+  setUp(() {
+    AppTester.create();
+  });
+
   test('RedundantAtKey checks that @-keys are only present in the main file',
       () {
-    AppTester.create();
-
-    final analyzerOptions = AnalyzerOptions(
-      rebellionOptions: RebellionOptions.empty(),
-      isSingleFile: false,
-      containsMainFile: true,
-    );
-
     var issues = RedundantAtKey().run(
       [
         createFile(
@@ -71,5 +74,41 @@ void main() {
       inMemoryLogger.output,
       'strings_es.arb: @-key "@key" should only be present in the main file',
     );
+  });
+
+  test('Rule can be ignored', () {
+    final issues = RedundantAtKey().run(
+      [
+        createFile(
+          filepath: 'strings_en.arb',
+          locale: 'en',
+          isMainFile: true,
+          values: {
+            'key': 'value',
+            '@key': AtKeyMeta(
+              description: 'description',
+              placeholders: [],
+              ignoredRulesRaw: [],
+            ),
+          },
+        ),
+        createFile(
+          filepath: 'strings_es.arb',
+          locale: 'es',
+          isMainFile: false,
+          values: {
+            'key': 'valor',
+            '@key': AtKeyMeta(
+              description: 'description',
+              placeholders: [],
+              ignoredRulesRaw: ['redundant_at_key'],
+            ),
+          },
+        ),
+      ],
+      analyzerOptions,
+    );
+    expect(issues, 0);
+    expect(inMemoryLogger.output, isEmpty);
   });
 }

--- a/test/src/analyze/rules/redundant_translations_test.dart
+++ b/test/src/analyze/rules/redundant_translations_test.dart
@@ -1,5 +1,6 @@
 import 'package:rebellion/src/analyze/analyzer_options.dart';
 import 'package:rebellion/src/analyze/rules/redundant_translations.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
 import 'package:rebellion/src/utils/rebellion_options.dart';
 import 'package:test/test.dart';
 
@@ -13,7 +14,7 @@ void main() {
   });
 
   test(
-      'RedundantTranslations reports not issue when there are no redundant translations',
+      'RedundantTranslations reports no issue when there are no redundant translations',
       () {
     final issues = RedundantTranslations().run(
       [
@@ -94,8 +95,8 @@ strings_es.arb: redundant translation "key5"
     final issues = RedundantTranslations().run(
       [
         createFile(
-          filepath: 'strings_en.arb',
-          locale: 'en',
+          filepath: 'strings_fi.arb',
+          locale: 'fi',
           isMainFile: false,
           values: {'key1': 'value'},
         ),
@@ -103,13 +104,50 @@ strings_es.arb: redundant translation "key5"
           filepath: 'strings_es.arb',
           locale: 'es',
           isMainFile: false,
-          values: {'key1': 'valor'},
+          values: {
+            'key1': 'valor',
+            'key2': 'valor',
+          },
         ),
       ],
       AnalyzerOptions(
         rebellionOptions: RebellionOptions.empty(),
         isSingleFile: false,
         containsMainFile: false,
+      ),
+    );
+    expect(issues, 0);
+    expect(inMemoryLogger.output, isEmpty);
+  });
+
+  test('Rule can be ignored', () {
+    final issues = RedundantTranslations().run(
+      [
+        createFile(
+          filepath: 'strings_en.arb',
+          locale: 'en',
+          isMainFile: true,
+          values: {'key1': 'value'},
+        ),
+        createFile(
+          filepath: 'strings_es.arb',
+          locale: 'es',
+          isMainFile: false,
+          values: {
+            'key1': 'valor',
+            'key2': 'valor',
+            '@key2': AtKeyMeta(
+              description: null,
+              placeholders: [],
+              ignoredRulesRaw: ['redundant_translations'],
+            ),
+          },
+        ),
+      ],
+      AnalyzerOptions(
+        rebellionOptions: RebellionOptions.empty(),
+        isSingleFile: false,
+        containsMainFile: true,
       ),
     );
     expect(issues, 0);

--- a/test/src/analyze/rules/sanity_check_test.dart
+++ b/test/src/analyze/rules/sanity_check_test.dart
@@ -1,0 +1,66 @@
+import 'package:rebellion/src/analyze/analyzer_options.dart';
+import 'package:rebellion/src/analyze/rules/rule.dart';
+import 'package:rebellion/src/analyze/rules/sanity_check.dart';
+import 'package:rebellion/src/utils/arb_parser/at_key_meta.dart';
+import 'package:rebellion/src/utils/rebellion_options.dart';
+import 'package:test/test.dart';
+
+import '../../../infrastructure/app_tester.dart';
+import '../../../infrastructure/logger.dart';
+import '../../../infrastructure/test_arb_files.dart';
+
+void main() {
+  final analyzerOptions = AnalyzerOptions(
+    rebellionOptions: RebellionOptions.empty(),
+    isSingleFile: true,
+    containsMainFile: true,
+  );
+
+  setUp(() {
+    AppTester.create();
+  });
+
+  test("SanityCheck doesn't report known rule names", () {
+    final issues = SanityCheck().run(
+      [
+        createFile(
+          values: {
+            'key': 'value',
+            '@key': AtKeyMeta(
+              description: null,
+              placeholders: [],
+              ignoredRulesRaw: [RuleKey.allCaps.key],
+            ),
+          },
+        ),
+      ],
+      analyzerOptions,
+    );
+    expect(issues, isZero);
+    expect(inMemoryLogger.output, isEmpty);
+  });
+
+  test('SanityCheck reports unknown ignored rules', () {
+    final issues = SanityCheck().run(
+      [
+        createFile(
+          values: {
+            'key': 'value',
+            '@key': AtKeyMeta(
+              description: null,
+              placeholders: [],
+              ignoredRulesRaw: ['something-something'],
+            ),
+          },
+        ),
+      ],
+      analyzerOptions,
+    );
+
+    expect(issues, 1);
+    expect(
+      inMemoryLogger.output,
+      'filepath: key "@key" contains unknown ignored rule: "something-something"',
+    );
+  });
+}

--- a/test/src/utils/extensions_test.dart
+++ b/test/src/utils/extensions_test.dart
@@ -37,6 +37,6 @@ void main() {
     expect('key_1'.toAtKey, '@key_1');
     expect('keyOne'.toAtKey, '@keyOne');
     expect('@key'.toAtKey, '@key');
-    expect(() => '@@locale'.toAtKey, throwsException);
+    expect('@@locale'.toAtKey, '@@locale');
   });
 }

--- a/test/src/utils/rebellion_options_test.dart
+++ b/test/src/utils/rebellion_options_test.dart
@@ -1,5 +1,6 @@
 import 'package:args/args.dart';
 import 'package:rebellion/src/analyze/rules/naming_convention.dart';
+import 'package:rebellion/src/analyze/rules/rule.dart';
 import 'package:rebellion/src/sort/sort.dart';
 import 'package:rebellion/src/utils/args.dart';
 import 'package:rebellion/src/utils/rebellion_options.dart';
@@ -30,6 +31,25 @@ void main() {
     final tester = AppTester.create();
     var options = RebellionOptions.loadYaml();
     expect(options, RebellionOptions.empty());
+    expect(options.mainLocale, 'en');
+    expect(options.sorting, Sorting.alphabetical);
+    expect(options.namingConvention, NamingConvention.camel);
+    expect(options.enabledRules, {
+      RuleKey.sanityCheck,
+      RuleKey.allCaps,
+      RuleKey.stringType,
+      RuleKey.atKeyType,
+      RuleKey.duplicatedKeys,
+      RuleKey.emptyAtKey,
+      RuleKey.localeDefinition,
+      RuleKey.missingPlaceholders,
+      RuleKey.missingPlurals,
+      RuleKey.missingTranslations,
+      RuleKey.redundantAtKey,
+      RuleKey.redundantTranslations,
+      RuleKey.unusedAtKey,
+      RuleKey.namingConvention,
+    });
 
     tester.setConfigFile('''
 rules:
@@ -73,10 +93,10 @@ options:
   sorting: follow-main-file
 ''');
     options = RebellionOptions.loadYaml();
-    expect(options.allCapsRuleEnabled, isFalse);
-    expect(options.stringTypeRuleEnabled, isFalse);
-    expect(options.atKeyTypeRuleEnabled, isTrue);
-    expect(options.unusedAtKeyRuleEnabled, isFalse);
-    expect(options.missingPluralsRuleEnabled, isFalse);
+    expect(options.enabledRules.contains(RuleKey.allCaps), isFalse);
+    expect(options.enabledRules.contains(RuleKey.stringType), isFalse);
+    expect(options.enabledRules.contains(RuleKey.atKeyType), isTrue);
+    expect(options.enabledRules.contains(RuleKey.unusedAtKey), isFalse);
+    expect(options.enabledRules.contains(RuleKey.missingPlurals), isFalse);
   });
 }


### PR DESCRIPTION
This pull request adds an option to ignore rules for specific ARB keys:

```json
{
  "indicatorLost": "X",
  "@indicatorLost": {
    "description": "Indicates a failed attempt",
    "@@x-ignore": ["all_caps"]
  }
}
```

* Part of #5
* Supports single values and lists of rules
* New `SanityCheck` is added to check if all ignored rules are known
* List of rules, options classes are refactored to use enum values
