### PR TITLE
Fix ARB file name parsing

### DIFF
--- a/lib/src/analyze/rules/locale_definition_allowlist.dart
+++ b/lib/src/analyze/rules/locale_definition_allowlist.dart
@@ -12,7 +12,7 @@ class LocaleDefinitionAllowlist extends Rule {
     int issues = 0;
 
     for (final file in files) {
-      final filenameLocale = file.file.locale.toLowerCase();
+      final filenameLocale = file.file.filenameLocale.toLowerCase();
       final contentLocale = file.content['@@locale']?.toLowerCase();
 
       if (!localesAllowlist.contains(filenameLocale)) {

--- a/lib/src/analyze/rules/locale_definition_match.dart
+++ b/lib/src/analyze/rules/locale_definition_match.dart
@@ -10,7 +10,7 @@ class LocaleDefinitionMatch extends Rule {
     int issues = 0;
 
     for (final file in files) {
-      final filenameLocale = file.file.locale.toLowerCase();
+      final filenameLocale = file.file.filenameLocale.toLowerCase();
       final contentLocale = file.content['@@locale']?.toLowerCase();
       if (contentLocale != null && filenameLocale != contentLocale) {
         issues++;

--- a/lib/src/analyze/rules/missing_plurals.dart
+++ b/lib/src/analyze/rules/missing_plurals.dart
@@ -37,10 +37,10 @@ class MissingPlurals extends Rule {
         final result = MessageParser(value).pluralGenderSelectParse();
         if (result is! Plural) continue;
 
-        final pluralRulesForLocale = pluralRules[file.file.locale];
+        final pluralRulesForLocale = pluralRules[file.locale];
         if (pluralRulesForLocale.isEmpty) {
           throw Exception(
-            'Failed to find plural rules for ${file.file.locale}',
+            'Failed to find plural rules for ${file.locale}',
           );
         }
 

--- a/lib/src/utils/arb_parser/arb_file.dart
+++ b/lib/src/utils/arb_parser/arb_file.dart
@@ -1,12 +1,12 @@
 import 'package:equatable/equatable.dart';
 
-/// Represents an ARB file
+/// Represents an ARB file on disk
 class ArbFile with EquatableMixin {
   /// Path to the ARB file
   final String filepath;
 
-  /// Locale of the ARB file
-  final String locale;
+  /// Locale of the ARB file parsed from the filename
+  final String filenameLocale;
 
   /// Whether the ARB file is the main file (default locale)
   final bool isMainFile;
@@ -14,12 +14,12 @@ class ArbFile with EquatableMixin {
   /// Default constructor
   const ArbFile({
     required this.filepath,
-    required this.locale,
+    required this.filenameLocale,
     required this.isMainFile,
   });
 
   // coverage:ignore-start
   @override
-  List<Object?> get props => [filepath, locale, isMainFile];
+  List<Object?> get props => [filepath, filenameLocale, isMainFile];
   // coverage:ignore-end
 }

--- a/lib/src/utils/arb_parser/parsed_arb_file.dart
+++ b/lib/src/utils/arb_parser/parsed_arb_file.dart
@@ -35,4 +35,10 @@ class ParsedArbFile with EquatableMixin {
   @override
   List<Object?> get props => [file, content, rawKeys];
   // coverage:ignore-end
+
+  /// Get locale of the file (@@locale or locale parsed from filename)
+  String get locale {
+    final arbLocale = content['@@locale'];
+    return arbLocale is String ? arbLocale : file.filenameLocale;
+  }
 }

--- a/rebellion_options.yaml
+++ b/rebellion_options.yaml
@@ -4,7 +4,6 @@ rules:
   - at_key_type
   - duplicated_keys
   - empty_at_key
-  - locale_definition
   - mandatory_at_key_description
   - missing_placeholders
   - missing_plurals
@@ -13,6 +12,9 @@ rules:
   - redundant_at_key
   - redundant_translations
   - unused_at_key
+  - locale_definition_presence
+  - locale_definition_allowlist
+  - locale_definition_match
 
 options:
   main_locale: en

--- a/test/infrastructure/test_arb_files.dart
+++ b/test/infrastructure/test_arb_files.dart
@@ -19,7 +19,7 @@ ParsedArbFile createFile({
   return ParsedArbFile(
     file: ArbFile(
       filepath: filepath,
-      locale: locale,
+      filenameLocale: locale,
       isMainFile: isMainFile,
     ),
     content: values,

--- a/test/src/analyze/analyzer_options_test.dart
+++ b/test/src/analyze/analyzer_options_test.dart
@@ -18,7 +18,7 @@ void main() {
     options = AnalyzerOptions.fromFiles(
       files: [
         ParsedArbFile(
-          file: ArbFile(filepath: '', locale: 'fi', isMainFile: false),
+          file: ArbFile(filepath: '', filenameLocale: 'fi', isMainFile: false),
           content: {},
           rawKeys: [],
         ),
@@ -32,7 +32,7 @@ void main() {
     options = AnalyzerOptions.fromFiles(
       files: [
         ParsedArbFile(
-          file: ArbFile(filepath: '', locale: 'en', isMainFile: true),
+          file: ArbFile(filepath: '', filenameLocale: 'en', isMainFile: true),
           content: {},
           rawKeys: [],
         ),
@@ -46,12 +46,12 @@ void main() {
     options = AnalyzerOptions.fromFiles(
       files: [
         ParsedArbFile(
-          file: ArbFile(filepath: '', locale: 'en', isMainFile: true),
+          file: ArbFile(filepath: '', filenameLocale: 'en', isMainFile: true),
           content: {},
           rawKeys: [],
         ),
         ParsedArbFile(
-          file: ArbFile(filepath: '', locale: 'fi', isMainFile: false),
+          file: ArbFile(filepath: '', filenameLocale: 'fi', isMainFile: false),
           content: {},
           rawKeys: [],
         ),

--- a/test/src/analyze/rules/duplicate_keys_test.dart
+++ b/test/src/analyze/rules/duplicate_keys_test.dart
@@ -24,7 +24,7 @@ void main() {
         ParsedArbFile(
           file: ArbFile(
             filepath: 'filepath',
-            locale: 'en',
+            filenameLocale: 'en',
             isMainFile: true,
           ),
           content: {
@@ -46,7 +46,7 @@ void main() {
         ParsedArbFile(
           file: ArbFile(
             filepath: 'filepath',
-            locale: 'en',
+            filenameLocale: 'en',
             isMainFile: true,
           ),
           content: {

--- a/test/src/analyze/rules/mandatory_key_description_test.dart
+++ b/test/src/analyze/rules/mandatory_key_description_test.dart
@@ -30,7 +30,7 @@ void main() {
         ParsedArbFile(
           file: ArbFile(
             filepath: 'filepath',
-            locale: 'en',
+            filenameLocale: 'en',
             isMainFile: true,
           ),
           content: {
@@ -56,7 +56,7 @@ void main() {
         ParsedArbFile(
           file: ArbFile(
             filepath: 'filepath',
-            locale: 'en',
+            filenameLocale: 'en',
             isMainFile: true,
           ),
           content: {

--- a/test/src/utils/arb_parser/arb_parser_test.dart
+++ b/test/src/utils/arb_parser/arb_parser_test.dart
@@ -19,7 +19,7 @@ void main() {
       () => parseArbFile(
         ArbFile(
           filepath: 'strings_en.arb',
-          locale: 'en',
+          filenameLocale: 'en',
           isMainFile: true,
         ),
       ),
@@ -41,7 +41,7 @@ void main() {
       () => parseArbFile(
         ArbFile(
           filepath: 'strings_en.arb',
-          locale: 'en',
+          filenameLocale: 'en',
           isMainFile: true,
         ),
       ),
@@ -76,7 +76,7 @@ void main() {
     final parsedFile = parseArbFile(
       ArbFile(
         filepath: 'strings_en.arb',
-        locale: 'en',
+        filenameLocale: 'en',
         isMainFile: true,
       ),
     );
@@ -122,7 +122,7 @@ void main() {
 
     final arbFile = ArbFile(
       filepath: 'strings_en.arb',
-      locale: 'en',
+      filenameLocale: 'en',
       isMainFile: true,
     );
     final parsedArbFile = parseArbFile(arbFile);
@@ -166,7 +166,7 @@ void main() {
 
     final arbFile = ArbFile(
       filepath: 'strings_en.arb',
-      locale: 'en',
+      filenameLocale: 'en',
       isMainFile: true,
     );
     final parsedArbFile = parseArbFile(arbFile);
@@ -189,7 +189,7 @@ void main() {
 
     final arbFile = ArbFile(
       filepath: 'intl_en.arb',
-      locale: 'en',
+      filenameLocale: 'en',
       isMainFile: true,
     );
     final parsedArbFile = parseArbFile(arbFile);
@@ -215,7 +215,7 @@ void main() {
 
     final arbFile = ArbFile(
       filepath: 'intl_en.arb',
-      locale: 'en',
+      filenameLocale: 'en',
       isMainFile: true,
     );
     final parsedArbFile = parseArbFile(arbFile);

--- a/test/src/utils/arb_parser/parsed_arb_file_test.dart
+++ b/test/src/utils/arb_parser/parsed_arb_file_test.dart
@@ -1,0 +1,44 @@
+import 'package:rebellion/src/utils/arb_parser/arb_file.dart';
+import 'package:rebellion/src/utils/arb_parser/parsed_arb_file.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('locale returns file locale code', () {
+    var parsedArbFile = ParsedArbFile(
+      file: ArbFile(
+        filepath: 'strings_en.arb',
+        filenameLocale: 'en',
+        isMainFile: true,
+      ),
+      content: {
+        '@@locale': 'en',
+      },
+      rawKeys: [],
+    );
+    expect(parsedArbFile.locale, 'en');
+
+    parsedArbFile = ParsedArbFile(
+      file: ArbFile(
+        filepath: 'strings_fi.arb',
+        filenameLocale: 'fi',
+        isMainFile: true,
+      ),
+      content: {
+        '@@locale': 'en',
+      },
+      rawKeys: [],
+    );
+    expect(parsedArbFile.locale, 'en');
+
+    parsedArbFile = ParsedArbFile(
+      file: ArbFile(
+        filepath: 'strings_fi.arb',
+        filenameLocale: 'fi',
+        isMainFile: true,
+      ),
+      content: {},
+      rawKeys: [],
+    );
+    expect(parsedArbFile.locale, 'fi');
+  });
+}

--- a/test/src/utils/file_utils_test.dart
+++ b/test/src/utils/file_utils_test.dart
@@ -21,7 +21,7 @@ void main() {
     expect(files.length, 1);
     expect(files.first.isMainFile, isTrue);
     expect(files.first.filepath, './strings_en.arb');
-    expect(files.first.locale, 'en');
+    expect(files.first.filenameLocale, 'en');
 
     files = getArbFiles(['./strings_en.arb', './strings_fi.arb'], 'en');
     expect(files.length, 2);
@@ -30,9 +30,9 @@ void main() {
     files = getArbFiles(['.'], 'en');
     expect(files.length, 2);
     expect(files[0].isMainFile, isTrue);
-    expect(files[0].locale, 'en');
+    expect(files[0].filenameLocale, 'en');
     expect(files[1].isMainFile, isFalse);
-    expect(files[1].locale, 'fi');
+    expect(files[1].filenameLocale, 'fi');
   });
 
   test('Writing ARB file writes valid JSON file', () {
@@ -47,7 +47,7 @@ void main() {
     expect(files.length, equals(1));
     expect(files.first.isMainFile, isTrue);
     expect(files.first.filepath, './strings_en.arb');
-    expect(files.first.locale, 'en');
+    expect(files.first.filenameLocale, 'en');
 
     final readFileContent = fileReader.readFile('./strings_en.arb');
     final readFile = json.decode(readFileContent);
@@ -64,8 +64,9 @@ void main() {
     expect(getLocaleFromFilepath('strings_fi_diff.arb'), null);
     expect(getLocaleFromFilepath('strings.yaml'), null);
     expect(getLocaleFromFilepath('strings_en.yaml'), null);
-    expect(getLocaleFromFilepath('strings_en_uk.arb'), 'en');
     expect(getLocaleFromFilepath('strings_en_US.arb'), 'en');
+    expect(getLocaleFromFilepath('strings_fil.arb'), 'fil');
+    expect(getLocaleFromFilepath('strings_gsw.arb'), 'gsw');
 
     expect(
       () => getLocaleFromFilepath('strings.arb'),


### PR DESCRIPTION
This PR fixes parsing of filenames. Now it supports 3-letters long language codes (e.g. `fil`).

Fix #19 